### PR TITLE
Register working 'clear' command

### DIFF
--- a/src/main/java/com/example/pun_prompt/config/CommandConfig.java
+++ b/src/main/java/com/example/pun_prompt/config/CommandConfig.java
@@ -75,4 +75,22 @@ public class CommandConfig {
                 .description("Prints a random joke to the console")
                 .build();
     }
+
+    @Bean
+    public CommandRegistration clearCommand() {
+        return CommandRegistration.builder()
+                .command("clear")
+                .withAlias()
+                .command("clean")
+                .and()
+                .withTarget()
+                .function(commandContext -> {
+                    System.out.print("\033[H\033[2J");
+                    System.out.flush();
+                    return "";
+                })
+                .and()
+                .description("Clears the terminal screen")
+                .build();
+    }
 }


### PR DESCRIPTION
This pull request fixes the built-in 'clear' command by providing a custom implementation along with an alias - 'clean'